### PR TITLE
Reduce prepare_dataset() peak memory

### DIFF
--- a/parafac2/normalize.py
+++ b/parafac2/normalize.py
@@ -13,6 +13,10 @@ def prepare_dataset(
     X_X = cast("csr_array", X.X)
     assert np.amin(X_X.data) >= 0.0
 
+    # Convert to float32 before filtering and copy to halve peak memory
+    if X_X.dtype != np.float32:
+        X_X.data = X_X.data.astype(np.float32)
+
     # Filter out genes with too few reads, and cells with fewer than 10 counts
     X = X[X_X.sum(axis=1) > 10, X_X.mean(axis=0) > geneThreshold]
 
@@ -20,10 +24,6 @@ def prepare_dataset(
     X._init_as_actual(X.copy())
     X.X = csr_array(X.X)
     X_X = cast("csr_array", X.X)
-
-    # Convert counts to floats
-    if issubclass(X_X.dtype.type, int | np.integer):
-        X_X.data = X_X.data.astype(np.float32)
 
     ## Normalize total counts per cell
     # Keep the counts on a reasonable scale to avoid accuracy issues
@@ -35,8 +35,10 @@ def prepare_dataset(
     # Scale genes by sum, inplace csr col scale
     X_X.data /= X_X.sum(axis=0).take(X_X.indices, mode="clip")
 
-    # Transform values
-    X_X.data = np.log10((1000.0 * X_X.data) + 1.0)
+    # Transform values in-place to avoid nnz-sized temporaries
+    X_X.data *= np.float32(1000.0)
+    X_X.data += np.float32(1.0)
+    np.log10(X_X.data, out=X_X.data)
 
     # Get the indices for subsetting the data
     _, sgIndex = np.unique(X.obs_vector(condition_name), return_inverse=True)


### PR DESCRIPTION
## Summary

- **Fix float32 cast**: The old condition \`issubclass(dtype, int | np.integer)\` silently skipped float64 input (which \`scipy.sparse.random\` produces), leaving all normalization and log10 operations running on float64 and doubling permanent memory use. Changed to \`dtype != np.float32\` and moved the cast _before_ the subset+copy so the copy itself works on the smaller float32 data.
- **In-place log10**: \`np.log10((1000.0 * X_X.data) + 1.0)\` allocated two nnz-sized temporaries before writing the result. Replaced with in-place \`*=\` / \`+=\` / \`np.log10(..., out=...)\`, eliminating ~382 MB of transient allocations at that step (for 50M nnz float32).

## Memory impact (50k cells × 20k genes, 50M nnz, float64 input)

| Metric | Before | After |
|---|---|---|
| Tracemalloc peak | 1337 MB | 1146 MB (−191 MB, −14%) |
| Result dtype | float64 | float32 |
| log10 step transient | ~600 MB | ~0 MB |

## Test plan

- [x] \`test_normalize.py::test_normalize\` passes